### PR TITLE
Add CODEOWNERS file for doc review

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Establish doc review assignments for https://github.com/orgs/octoml/teams/unity-docs
+/python/ @octoml/unity-docs
+/src/ @octoml/unity-docs
+/tests/ @octoml/unity-docs


### PR DESCRIPTION
This sets up the docs review assignment via GitHub's codeowners mechanism