### PR TITLE
[TUZ-152] Implement a pass that applies scheduling for a target backend

### DIFF
--- a/python/tvm/meta_schedule/relax_integration.py
+++ b/python/tvm/meta_schedule/relax_integration.py
@@ -146,11 +146,11 @@ def tune_relax(
     target: Union[str, Target],
     work_dir: str,
     max_trials_global: int,
-    *,
     max_trials_per_task: Optional[int] = None,
     num_trials_per_iter: int = 64,
     builder: Builder.BuilderType = "local",
     runner: Runner.RunnerType = "local",
+    *,
     database: Database.DatabaseType = "json",
     cost_model: CostModel.CostModelType = "xgb",
     measure_callbacks: MeasureCallback.CallbackListType = "default",
@@ -231,11 +231,11 @@ def _tune_relax(
     target: Union[str, Target],
     work_dir: str,
     max_trials_global: int,
-    *,
     max_trials_per_task: Optional[int] = None,
     num_trials_per_iter: int = 64,
     builder: Builder.BuilderType = "local",
     runner: Runner.RunnerType = "local",
+    *,
     database: Database.DatabaseType = "json",
     cost_model: CostModel.CostModelType = "xgb",
     measure_callbacks: MeasureCallback.CallbackListType = "default",
@@ -286,6 +286,13 @@ def _tune_relax(
     ret_mod : IRModule
         IRModule
     """
+
+    if isinstance(num_trials_per_iter, IntImm):
+        num_trials_per_iter = int(num_trials_per_iter)
+
+    if isinstance(max_trials_per_task, IntImm):
+        max_trials_per_task = int(max_trials_per_task)
+
     if isinstance(max_trials_global, IntImm):
         max_trials_global = int(max_trials_global)
 

--- a/python/tvm/meta_schedule/tir_integration.py
+++ b/python/tvm/meta_schedule/tir_integration.py
@@ -45,10 +45,10 @@ def tune_tir(
     target: Union[str, Target],
     work_dir: str,
     max_trials_global: int,
-    *,
     num_trials_per_iter: int = 64,
     builder: Builder.BuilderType = "local",
     runner: Runner.RunnerType = "local",
+    *,
     database: Database.DatabaseType = "json",
     cost_model: CostModel.CostModelType = "xgb",
     measure_callbacks: MeasureCallback.CallbackListType = "default",
@@ -103,6 +103,7 @@ def tune_tir(
     """
     (logger,) = get_loggers_from_work_dir(work_dir, [task_name])
     (seed,) = fork_seed(seed, n=1)
+    num_trials_per_iter = int(num_trials_per_iter)
     return tune_tasks(
         tasks=[
             TuneContext(
@@ -136,10 +137,10 @@ def _tune_tir(
     target: Union[str, Target],
     work_dir: str,
     max_trials_global: int,
-    *,
     num_trials_per_iter: int = 64,
     builder: Builder.BuilderType = "local",
     runner: Runner.RunnerType = "local",
+    *,
     database: Database.DatabaseType = "json",
     cost_model: CostModel.CostModelType = "xgb",
     measure_callbacks: MeasureCallback.CallbackListType = "default",

--- a/python/tvm/relax/transform/__init__.py
+++ b/python/tvm/relax/transform/__init__.py
@@ -20,3 +20,4 @@
 from .transform import *
 from .fma_rewrite import *
 from .legalize_ops import LegalizeOps
+from .schedule import ScheduleForTarget

--- a/python/tvm/relax/transform/schedule.py
+++ b/python/tvm/relax/transform/schedule.py
@@ -88,7 +88,7 @@ class ScheduleForTarget:
         # Perform a minimal set of metaschedule tuning on the input module.
         with tempfile.TemporaryDirectory() as work_dir:
             with self.target, transform.PassContext(trace=Trace(mod), opt_level=0):
-                # Create a pass that performs a few trials per task in the module.
+                # Create a pass that finds one valid schedule per task in the module.
                 tuning_pass = relax.transform.MetaScheduleTuneIRMod(
                     params={},
                     work_dir=work_dir,

--- a/python/tvm/relax/transform/schedule.py
+++ b/python/tvm/relax/transform/schedule.py
@@ -1,0 +1,89 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name
+"""Relax passes related to scheduling functions for target hardware."""
+import tempfile
+from typing import Union, List
+
+from tvm import relax
+from tvm.ir import transform
+from tvm.target import Target
+from tvm import meta_schedule as ms
+from .tuning_api import Trace
+
+
+@transform.module_pass(opt_level=2, name="schedule_for_target")
+class ScheduleForTarget:
+    def __init__(self, target: Union[Target, str]):
+        """Apply a minimal set of transformations to enable running on a specific target.
+
+        This function returns a pass which applies basic schedule transformations to each
+        primitive function in the input module for the specified target. This is useful
+        when a hardware target requires certain intrinsics for kernels to be valid. For
+        example, on GPUs, each kernel must have loops bound to a thread and block index.
+        By default, primitive functions do not contain this binding. Applying a single
+        step of Metaschedule's transform rules inserts bindings that enable the functions
+        to be run.
+
+        Thus, this pass is a convenience wrapper around the simplist possible invocation
+        of Metaschedule tuning. It performs only a few schedules per task, skips benchmarking,
+        and verifies that they can be built.
+
+        Parameters
+        ----------
+        target : Union[Target, str]
+            The tvm target that fucntions should be scheduled for.
+        """
+        if isinstance(target, str):
+            target = Target(target)
+        self.target = target
+        # Create a fake runner function that does not perform benchmarking. This
+        # allows us to save time when transforming primitive functions in the module.
+        @ms.derived_object
+        class FakeRunner(ms.runner.PyRunner):
+            def run(
+                self, runner_inputs: List[ms.runner.RunnerInput]
+            ) -> List[ms.runner.RunnerFuture]:
+                return [ms.runner.LocalRunnerFuture([0.0], None)]
+
+        self.runner = FakeRunner()
+
+    def transform_module(self, mod, ctx):
+        # Extract the number of tasks in the input module so that we can
+        # determine the minimal number of transformations to try.
+        num_tasks = len(ms.relax_integration.extract_tasks(mod, self.target))
+
+        # Perform a minimal set of metaschedule tuning on the input module.
+        with tempfile.TemporaryDirectory() as work_dir:
+            with self.target, transform.PassContext(trace=Trace(mod), opt_level=0):
+                # Create a pass that performs a few trials per task in the module.
+                tuning_pass = relax.transform.MetaScheduleTuneIRMod(
+                    params={},
+                    work_dir=work_dir,
+                    max_trials_global=4 * num_tasks,
+                    max_trials_per_task=1,
+                    runner=self.runner,
+                )
+
+                # Apply the pass on our module.
+                mod = tuning_pass(mod)
+
+                # Use the results of tuning to schedule the module.
+                application_pass = relax.transform.MetaScheduleApplyDatabase(work_dir)
+                mod = application_pass(mod)
+
+        return mod

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -446,7 +446,9 @@ def MetaScheduleTuneIRMod(
     """
     if runner is None:
         runner = ms.runner.LocalRunner()
-    return _ffi_api.MetaScheduleTuneIRMod(params, work_dir, max_trials_global, max_trials_per_task, runner)  # type: ignore
+    return _ffi_api.MetaScheduleTuneIRMod(  # type: ignore
+        params, work_dir, max_trials_global, max_trials_per_task, runner
+    )
 
 
 def _wrap_class_function_pass(pass_cls, pass_info):

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -24,6 +24,7 @@ import numpy as np  # type: ignore
 
 import tvm.ir
 from tvm.runtime import NDArray
+from tvm import meta_schedule as ms
 from . import _ffi_api
 
 
@@ -399,6 +400,7 @@ def MetaScheduleApplyDatabase(
 def MetaScheduleTuneTIR(
     work_dir: str,
     max_trials_global: int,
+    runner: Optional[ms.runner.Runner] = None,
 ) -> tvm.ir.transform.Pass:
     """Tune TIR with MetaSchedule.
     Parameters
@@ -407,17 +409,23 @@ def MetaScheduleTuneTIR(
        work directory
     max_trials_gloabl: int
        maximum number of total trials allowed for tuning
+    runner: Optional[ms.runner.Runner]
+       runner for tuning
     Returns
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.MetaScheduleTuneTIR(work_dir, max_trials_global)  # type: ignore
+    if runner is None:
+        runner = ms.runner.LocalRunner()
+    return _ffi_api.MetaScheduleTuneTIR(work_dir, max_trials_global, runner)  # type: ignore
 
 
 def MetaScheduleTuneIRMod(
     params: Dict[str, NDArray],
     work_dir: str,
     max_trials_global: int,
+    max_trials_per_task: Optional[int] = None,
+    runner: Optional[ms.runner.Runner] = None,
 ) -> tvm.ir.transform.Pass:
     """Tune Relax IRModule with MetaSchedule.
     Parameters
@@ -428,11 +436,17 @@ def MetaScheduleTuneIRMod(
        work directory
     max_trials_gloabl: int
        maximum number of total trials allowed for tuning
+    max_trials_per_task: Optional[int]
+       maximum number of trials allowed for each task
+    runner: Optional[ms.runner.Runner]
+       runner for the tuning pass
     Returns
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.MetaScheduleTuneIRMod(params, work_dir, max_trials_global)  # type: ignore
+    if runner is None:
+        runner = ms.runner.LocalRunner()
+    return _ffi_api.MetaScheduleTuneIRMod(params, work_dir, max_trials_global, max_trials_per_task, runner)  # type: ignore
 
 
 def _wrap_class_function_pass(pass_cls, pass_info):

--- a/python/tvm/relax/transform/tuning_api/primitives.py
+++ b/python/tvm/relax/transform/tuning_api/primitives.py
@@ -21,10 +21,10 @@ import logging
 import tvm
 from tvm.runtime import Object
 from tvm.ir.module import IRModule
-from tvm.relax import Expr
 from tvm.tir.schedule.trace import JSON_TYPE, _json_from_tvm
 from tvm._ffi import register_object
 from . import _ffi_api
+from ...expr import Expr
 
 logger = logging.getLogger("TuningAPI")  # pylint: disable=invalid-name
 

--- a/src/meta_schedule/utils.h
+++ b/src/meta_schedule/utils.h
@@ -154,8 +154,6 @@ inline void clear_logging(const char* file, int lineno, PackedFunc logging_func)
     logging_func(static_cast<int>(PyLogMessage::Level::CLEAR), file, lineno, "");
   } else {
     // this would clear all logging output in the console
-    // runtime::detail::LogMessage(file, lineno, TVM_LOG_LEVEL_INFO).stream()
-    //    << "\033c\033[3J\033[2J\033[0m\033[H";
     logging_func(static_cast<int>(PyLogMessage::Level::INFO), file, lineno,
                  "\033c\033[3J\033[2J\033[0m\033[H");
   }

--- a/src/meta_schedule/utils.h
+++ b/src/meta_schedule/utils.h
@@ -154,8 +154,10 @@ inline void clear_logging(const char* file, int lineno, PackedFunc logging_func)
     logging_func(static_cast<int>(PyLogMessage::Level::CLEAR), file, lineno, "");
   } else {
     // this would clear all logging output in the console
-    runtime::detail::LogMessage(file, lineno, TVM_LOG_LEVEL_INFO).stream()
-        << "\033c\033[3J\033[2J\033[0m\033[H";
+    // runtime::detail::LogMessage(file, lineno, TVM_LOG_LEVEL_INFO).stream()
+    //    << "\033c\033[3J\033[2J\033[0m\033[H";
+    logging_func(static_cast<int>(PyLogMessage::Level::INFO), file, lineno,
+                 "\033c\033[3J\033[2J\033[0m\033[H");
   }
 }
 

--- a/src/relax/transform/meta_schedule.cc
+++ b/src/relax/transform/meta_schedule.cc
@@ -34,8 +34,7 @@ namespace transform {
 class MetaScheduleTuner {
  public:
   explicit MetaScheduleTuner(Target target, String work_dir, Integer max_trials_global,
-                             Integer max_trials_per_task,
-                             meta_schedule::Runner runner,
+                             Integer max_trials_per_task, meta_schedule::Runner runner,
                              Map<String, runtime::NDArray> params = {})
       : target_(target),
         work_dir_(work_dir),
@@ -56,8 +55,8 @@ class MetaScheduleTuner {
     String builder = "local";
     Integer num_trials_per_iter = 64;
     Choice choice("tvm.meta_schedule.tune_relax",
-      {params_, target_, work_dir_, max_trials_global_, max_trials_per_task_,
-      num_trials_per_iter, builder, runner_},
+                  {params_, target_, work_dir_, max_trials_global_, max_trials_per_task_,
+                   num_trials_per_iter, builder, runner_},
                   "relax.tuning_api.Choice.default_constr_func", {});
     Knob knob("meta_schedule.tune_irmod", {{"0", choice}});
     Array<Trace> candidates = (*candgen_func_)(Array<Knob>({knob}), trace);
@@ -75,7 +74,8 @@ class MetaScheduleTuner {
     Trace trace = Trace((*normalize_mod_func_)(f), {}, {});
     String builder = "local";
     Integer num_trials_per_iter = 64;
-    Choice choice("tvm.meta_schedule.tune_tir", {target_, work_dir_, max_trials_global_, num_trials_per_iter, builder, runner_},
+    Choice choice("tvm.meta_schedule.tune_tir",
+                  {target_, work_dir_, max_trials_global_, num_trials_per_iter, builder, runner_},
                   "relax.tuning_api.Choice.default_constr_func", {});
     Knob knob("meta_schedule.tune_primfunc", {{"0", choice}});
     Array<Trace> candidates = (*candgen_func_)(Array<Knob>({knob}), trace);
@@ -150,11 +150,14 @@ Pass MetaScheduleApplyDatabase(Optional<String> work_dir) {
 }
 
 Pass MetaScheduleTuneIRMod(Map<String, runtime::NDArray> params, String work_dir,
-                           Integer max_trials_global, Integer max_trials_per_task, meta_schedule::Runner runner) {
+                           Integer max_trials_global, Integer max_trials_per_task,
+                           meta_schedule::Runner runner) {
   Target target = Target::Current(false);
   runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func = [=](IRModule m,
                                                                             PassContext ctx) {
-    return MetaScheduleTuner(target, work_dir, max_trials_global, max_trials_per_task, runner, params).TuneIRMod(m, ctx);
+    return MetaScheduleTuner(target, work_dir, max_trials_global, max_trials_per_task, runner,
+                             params)
+        .TuneIRMod(m, ctx);
   };
   return CreateModulePass(/*pass function*/ pass_func, /*opt level*/ 0,
                           /*pass name*/ "MetaScheduleTuneIRModule",
@@ -166,7 +169,8 @@ Pass MetaScheduleTuneTIR(String work_dir, Integer max_trials_global, meta_schedu
   Target target = Target::Current(false);
   runtime::TypedPackedFunc<tir::PrimFunc(tir::PrimFunc, IRModule, PassContext)> pass_func =
       [=](tir::PrimFunc f, IRModule mod, PassContext ctx) {
-        return MetaScheduleTuner(target, work_dir, max_trials_global, max_trials_global, runner).TuneTIR(f, ctx);
+        return MetaScheduleTuner(target, work_dir, max_trials_global, max_trials_global, runner)
+            .TuneTIR(f, ctx);
       };
   return tir::transform::CreatePrimFuncPass(/*pass function*/ pass_func, /*opt level*/ 0,
                                             /*pass name*/ "MetaScheduleTuneTIR",

--- a/tests/python/relax/test_transform_meta_schedule_tuning.py
+++ b/tests/python/relax/test_transform_meta_schedule_tuning.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import List
 import tempfile
 
 import tvm
@@ -79,7 +80,9 @@ def test_ms_tuning_irmodule():
     with tempfile.TemporaryDirectory() as work_dir:
         with target, transform.PassContext(trace=Trace(mod), opt_level=0):
             tuning_pass = relax.transform.MetaScheduleTuneIRMod(
-                params={}, work_dir=work_dir, max_trials_global=4
+                params={},
+                work_dir=work_dir,
+                max_trials_global=4,
             )
             out_mod = tuning_pass(mod)
             assert PassContext.current().get_trace_stack_size() == 1
@@ -111,5 +114,34 @@ def test_ms_tuning_primfunc():
             assert not tvm.ir.structural_equal(mod, out_mod)
 
 
+def test_ms_tuning_minimal():
+    @ms.derived_object
+    class FakeRunner(ms.runner.PyRunner):
+        def run(self, runner_inputs: List[ms.runner.RunnerInput]) -> List[ms.runner.RunnerFuture]:
+            return [ms.runner.LocalRunnerFuture([0.0], None)]
+
+    mod = InputModule
+    assert isinstance(mod, IRModule)
+
+    with tempfile.TemporaryDirectory() as work_dir:
+        with target, transform.PassContext(trace=Trace(mod), opt_level=0):
+            tuning_pass = relax.transform.MetaScheduleTuneIRMod(
+                params={},
+                work_dir=work_dir,
+                max_trials_global=4,
+                max_trials_per_task=1,
+                runner=FakeRunner(),
+            )
+            out_mod = tuning_pass(mod)
+            assert PassContext.current().get_trace_stack_size() == 1
+            assert PassContext.current().get_current_trace().size == 1
+            tvm.ir.assert_structural_equal(mod, out_mod)
+
+            application_pass = relax.transform.MetaScheduleApplyDatabase(work_dir)
+
+            out_mod = application_pass(mod)
+            assert not tvm.ir.structural_equal(mod, out_mod)
+
+
 if __name__ == "__main__":
-    tvm.testing.main()
+    test_ms_tuning_minimal()

--- a/tests/python/relax/test_transform_meta_schedule_tuning.py
+++ b/tests/python/relax/test_transform_meta_schedule_tuning.py
@@ -122,13 +122,13 @@ def test_ms_tuning_minimal():
 
     mod = InputModule
     assert isinstance(mod, IRModule)
-
+    num_tasks = len(ms.relax_integration.extract_tasks(mod, target))
     with tempfile.TemporaryDirectory() as work_dir:
         with target, transform.PassContext(trace=Trace(mod), opt_level=0):
             tuning_pass = relax.transform.MetaScheduleTuneIRMod(
                 params={},
                 work_dir=work_dir,
-                max_trials_global=4,
+                max_trials_global=4 * num_tasks,
                 max_trials_per_task=1,
                 runner=FakeRunner(),
             )
@@ -144,4 +144,4 @@ def test_ms_tuning_minimal():
 
 
 if __name__ == "__main__":
-    test_ms_tuning_minimal()
+    tvm.testing.main()

--- a/tests/python/relax/test_transform_schedule_for_target.py
+++ b/tests/python/relax/test_transform_schedule_for_target.py
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import List
+import tempfile
+
+import tvm
+import tvm.testing
+import tvm.meta_schedule as ms
+from tvm import relax
+from tvm.ir import transform
+from tvm.ir.module import IRModule
+from tvm.ir.transform import PassContext
+from tvm.relax.transform.tuning_api import Trace
+from tvm.script import relax as R
+from tvm.script import tir as T
+
+
+@tvm.script.ir_module
+class InputModule:
+    @T.prim_func
+    def tir_matmul(x: T.handle, y: T.handle, z: T.handle) -> None:
+        T.func_attr({"global_symbol": "tir_matmul"})
+        k = T.var("int32")
+        A = T.match_buffer(x, (32, 32))
+        B = T.match_buffer(y, (32, 32))
+        C = T.match_buffer(z, (32, 32))
+
+        for (i0, j0, k0) in T.grid(32, 32, 32):
+            with T.block():
+                i, j, k = T.axis.remap("SSR", [i0, j0, k0])
+                with T.init():
+                    C[i, j] = 0.0
+                C[i, j] += A[i, k] * B[j, k]
+
+    @T.prim_func
+    def tir_relu(x: T.handle, y: T.handle):
+        T.func_attr({"global_symbol": "tir_relu"})
+        A = T.match_buffer(x, (32, 32))
+        B = T.match_buffer(y, (32, 32))
+        for (i, j) in T.grid(32, 32):
+            with T.block():
+                vi, vj = T.axis.remap("SS", [i, j])
+                B[vi, vj] = T.max(A[vi, vj], 0.0)
+
+    @R.function
+    def main(x: R.Tensor((32, 32), "float32"), w: R.Tensor((32, 32), "float32")) -> R.Tensor:
+        with R.dataflow():
+            lv0 = R.call_tir(tir_matmul, (x, w), R.Tensor((32, 32), dtype="float32"))
+            lv1 = R.call_tir(tir_relu, (lv0), R.Tensor((32, 32), dtype="float32"))
+            R.output(lv1)
+        return lv1
+
+
+@tvm.testing.parametrize_targets(
+    "llvm --num-cores=2",
+    "cuda -max_shared_memory_per_block=49152 -max_threads_per_block=1024 -registers_per_block=65536 -thread_warp_size=32",
+)
+def test_schedule_for_target(target, dev):
+    # Check that input device is valid on current machine.
+    if dev in [enabled_dev for _, enabled_dev in tvm.testing.enabled_targets()]:
+        mod = InputModule
+        assert isinstance(mod, IRModule)
+        out_mod = relax.transform.ScheduleForTarget(target)(mod)
+        assert not tvm.ir.structural_equal(mod, out_mod)
+
+        # Perform an additional check depending on the target.
+        if dev == tvm.cpu():
+            # On CPU, parallelization should have been inserted.
+            assert "parallel" in out_mod.astext()
+        if dev == tvm.gpu():
+            # On GPU, thread bindings should have been inserted.
+            assert "thread_binding" in out_mod.astext()
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_transform_schedule_for_target.py
+++ b/tests/python/relax/test_transform_schedule_for_target.py
@@ -81,10 +81,10 @@ def test_schedule_for_target(target, dev):
         # Perform an additional check depending on the target.
         if dev == tvm.cpu():
             # On CPU, parallelization should have been inserted.
-            assert "parallel" in out_mod.astext()
+            assert "parallel" in out_mod.script()
         if dev == tvm.gpu():
             # On GPU, thread bindings should have been inserted.
-            assert "thread_binding" in out_mod.astext()
+            assert "thread_binding" in out_mod.script()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a convenience wrapper around metaschedule tuning to perform scheduling transformations to each primitive function in a module for a target device. The usage of the pass is as follows:
```
original_mod = MyIRModule
scheduled_mod = relax.transform.ScheduleForTarget("cuda")(original_mod)
```
`scheduled_mod` will have gpu thread and block bindings inserted that allow it to be compiled for gpu.