### PR TITLE
[CI] Add onnx dependency to cpu ci image

### DIFF
--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -144,3 +144,7 @@ ENV PATH /opt/sccache:$PATH
 # Libxsmm deps
 COPY install/ubuntu_install_libxsmm.sh /install
 RUN bash /install/ubuntu_install_libxsmm.sh
+
+# Onnx deps
+COPY install/ubuntu_install_onnx.sh /install/ubuntu_install_onnx.sh
+RUN bash /install/ubuntu_install_onnx.sh


### PR DESCRIPTION
This small PR installs onnx in the ci_cpu docker image. This is needed to run our onnx frontend tests.