### PR TITLE
Re-enable sccache in octo fork

### DIFF
--- a/tests/scripts/task_config_build_cpu.sh
+++ b/tests/scripts/task_config_build_cpu.sh
@@ -34,7 +34,7 @@ echo set\(USE_BLAS openblas\) >> config.cmake
 # echo set\(USE_NNPACK ON\) >> config.cmake
 # echo set\(NNPACK_PATH /NNPACK/build/\) >> config.cmake
 # echo set\(USE_ANTLR ON\) >> config.cmake
-echo set\(CMAKE_CXX_COMPILER g++\) >> config.cmake
+#echo set\(CMAKE_CXX_COMPILER g++\) >> config.cmake
 echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
 # echo set\(HIDE_PRIVATE_SYMBOLS ON\) >> config.cmake
 # echo set\(USE_VTA_TSIM ON\) >> config.cmake


### PR DESCRIPTION
This PR stops overriding the CXX compiler so we can use sccache to speed up builds in CI.

@driazati @jwfromm 