### PR TITLE
[Bug] Fix issue in einsum check

### DIFF
--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -118,11 +118,11 @@ class PrimExpr : public BaseExpr {
    * \param value The value to be constructed.
    */
   TVM_DLL PrimExpr(int32_t value);  // NOLINT(*)
-    /*!
+  /*!
    * \brief construct from 64bit integer.
    * \param value The value to be constructed.
    */
-  TVM_DLL  PrimExpr(int64_t value);  // NOLINT(*)
+  TVM_DLL PrimExpr(int64_t value);  // NOLINT(*)
   /*!
    * \brief construct from float.
    * \param value The value to be constructed.

--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -114,10 +114,15 @@ class PrimExprNode : public BaseExprNode {
 class PrimExpr : public BaseExpr {
  public:
   /*!
-   * \brief construct from integer.
+   * \brief construct from 32bit integer.
    * \param value The value to be constructed.
    */
   TVM_DLL PrimExpr(int32_t value);  // NOLINT(*)
+    /*!
+   * \brief construct from 64bit integer.
+   * \param value The value to be constructed.
+   */
+  TVM_DLL  PrimExpr(int64_t value);  // NOLINT(*)
   /*!
    * \brief construct from float.
    * \param value The value to be constructed.

--- a/src/ir/expr.cc
+++ b/src/ir/expr.cc
@@ -34,6 +34,8 @@ namespace tvm {
 
 PrimExpr::PrimExpr(int32_t value) : PrimExpr(IntImm(DataType::Int(32), value)) {}
 
+PrimExpr::PrimExpr(int64_t value) : PrimExpr(IntImm(DataType::Int(64), value)) {}
+
 PrimExpr::PrimExpr(float value) : PrimExpr(FloatImm(DataType::Float(32), value)) {}
 
 PrimExpr PrimExpr::FromObject_(ObjectRef ref) {

--- a/src/topi/einsum.cc
+++ b/src/topi/einsum.cc
@@ -270,7 +270,8 @@ class EinsumBuilder {
         }
       } else {
         // Normal label
-        reduction_axes->push_back(IterVar(Range(0, label_to_extent_[label]),
+        const IntImmNode* extent = label_to_extent_[label].as<IntImmNode>();
+        reduction_axes->push_back(IterVar(Range(0, extent->value),
                                           Var(std::string(1, label), DataType::Int(64)),
                                           IterVarType::kCommReduce));
         label_to_index->emplace(label, reduction_axes->back()->var);


### PR DESCRIPTION
Einsum CI test fail due to check of range and var type in GPU CI tests:

> at ../src/topi/einsum.cc:273
[2023-02-28T07:58:23.317Z] E     0: tvm::tir::IterVar::IterVar(tvm::Range, tvm::tir::Var, tvm::tir::IterVarType, tvm::runtime::String, tvm::Span)
[2023-02-28T07:58:23.317Z] E           at ../src/tir/ir/expr.cc:143
[2023-02-28T07:58:23.317Z] E     File "../src/tir/ir/expr.cc", line 143
[2023-02-28T07:58:23.317Z] E   TVMError: Check failed: dom->extent.dtype() == var.dtype() (int32 vs. int64) : The dtype of the extent of an IterVar (int32) must match its associated Var's dtype (int64)

Looks like PrimExpr assumes int32 for integer by default.
**I fix only GPU CI tests, CPU CI still fails due to other issues.**

Details: I also saw this discussion [thread](https://github.com/octoml/relax/pull/23#discussion_r1116154211)