### PR TITLE
[CI] fix unity build failure related to undefined symbols in tflite

### DIFF
--- a/cmake/modules/contrib/TFLite.cmake
+++ b/cmake/modules/contrib/TFLite.cmake
@@ -39,6 +39,10 @@ if(NOT USE_TFLITE STREQUAL "OFF")
   endif()
   find_library(TFLITE_CONTRIB_LIB libtensorflow-lite.a ${USE_TFLITE})
   file(GLOB_RECURSE TFLITE_DEPS "${USE_TFLITE}/*.a")
+  # the order of the next libs are important for correct build
+  list(REMOVE_ITEM TFLITE_DEPS "${USE_TFLITE}/_deps/clog-build/libclog.a" "${USE_TFLITE}/_deps/cpuinfo-build/libcpuinfo.a")
+  list(APPEND TFLITE_DEPS "${USE_TFLITE}/_deps/cpuinfo-build/libcpuinfo.a")
+  list(APPEND TFLITE_DEPS "${USE_TFLITE}/_deps/clog-build/libclog.a")
 
   list(APPEND TVM_RUNTIME_LINKER_LIBS ${TFLITE_CONTRIB_LIB})
   list(APPEND TVM_RUNTIME_LINKER_LIBS ${TFLITE_DEPS})

--- a/python/tvm/relax/frontend/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx_frontend.py
@@ -34,7 +34,7 @@ If this fails, there may still be dynamic operations in the model.
 Not all TVM kernels currently support dynamic shapes, please file an issue on
 github.com/apache/tvm/issues if you hit an error with dynamic kernels.
 """
-import math
+# import math
 import warnings
 from typing import Union, List, Dict, Tuple, Any
 import onnx.onnx_ml_pb2

--- a/src/topi/einsum.cc
+++ b/src/topi/einsum.cc
@@ -264,14 +264,15 @@ class EinsumBuilder {
         // Ellipsis
         auto ellipsis_shape = ellipsis_shape_.value();
         for (int i = 0; i < static_cast<int>(ellipsis_shape.size()); ++i) {
-          reduction_axes->push_back(
-              IterVar(Range(0, ellipsis_shape[i]), Var("k", DataType::Int(64)), IterVarType::kCommReduce));
+          reduction_axes->push_back(IterVar(Range(0, ellipsis_shape[i]),
+                                            Var("k", DataType::Int(64)), IterVarType::kCommReduce));
           ellipsis_indices->push_back(reduction_axes->back()->var);
         }
       } else {
         // Normal label
         reduction_axes->push_back(IterVar(Range(0, label_to_extent_[label]),
-                                          Var(std::string(1, label), DataType::Int(64)), IterVarType::kCommReduce));
+                                          Var(std::string(1, label), DataType::Int(64)),
+                                          IterVarType::kCommReduce));
         label_to_index->emplace(label, reduction_axes->back()->var);
       }
     }


### PR DESCRIPTION
Currently CI fails during tflite build with the next issue:

> [2023-03-02T07:44:01.761Z] /opt/tflite/_deps/cpuinfo-build/libcpuinfo.a(api.c.o): In function `cpuinfo_log_fatal.constprop.0':
> [2023-03-02T07:44:01.761Z] api.c:(.text+0xa3): undefined reference to `clog_vlog_fatal'
> [2023-03-02T07:44:01.761Z] /opt/tflite/_deps/cpuinfo-build/libcpuinfo.a(init.c.o): In function `cpuinfo_log_error':
> [2023-03-02T07:44:01.761Z] init.c:(.text+0x9f): undefined reference to `clog_vlog_error'
> [2023-03-02T07:44:01.761Z] /opt/tflite/_deps/cpuinfo-build/libcpuinfo.a(processors.c.o): In function `cpuinfo_log_error':
> [2023-03-02T07:44:01.761Z] processors.c:(.text+0x10f): undefined reference to `clog_vlog_error'
> [2023-03-02T07:44:01.761Z] /opt/tflite/_deps/cpuinfo-build/libcpuinfo.a(smallfile.c.o): In function `cpuinfo_log_error.constprop.0':
> [2023-03-02T07:44:01.761Z] smallfile.c:(.text+0xa3): undefined reference to `clog_vlog_error'
> [2023-03-02T07:44:01.761Z] /usr/bin/ld: libtvm_runtime.so: internal symbol `clog_vlog_fatal' isn't defined
> [2023-03-02T07:44:01.761Z] /usr/bin/ld: final link failed: Bad value
> [2023-03-02T07:44:01.761Z] collect2: error: ld returned 1 exit status

Fix was done based on similar [issue](https://github.com/pytorch/pytorch/issues/13881) for Caffe2

By product: lint fixes were done