### PR TITLE
[CI] Point cpu ci to dep with onnx

### DIFF
--- a/ci/jenkins/unity_jenkinsfile.groovy
+++ b/ci/jenkins/unity_jenkinsfile.groovy
@@ -32,7 +32,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: these lines are scanned by docker/dev_common.sh. Please update the regex as needed. -->
 ci_lint = 'tlcpack/ci-lint:20221025-182121-e41d0ed6e'
 ci_gpu = 'tlcpack/ci-gpu:20221128-070141-ae4fd7df7'
-ci_cpu = 'tlcpack/ci-cpu:20230110-070003-d00168ffb'
+ci_cpu = 'tlcpack/ci-cpu:relax-20230217-001605-fcb3d9e71'
 ci_wasm = 'tlcpack/ci-wasm:v0.72'
 ci_i386 = 'tlcpack/ci-i386:v0.75'
 ci_qemu = 'tlcpack/ci-qemu:v0.11'


### PR DESCRIPTION
This changes the unity jenkins file to pull a CI image with onnx for cpu tests. I think this should help unblock ci builds @vvchernov @driazati 