### PR TITLE
[TUZ-200] Change Slice to Relax Op

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -878,9 +878,7 @@ class Slice(OnnxOpConverter):
             assert all(len(i) == 1 for i in [starts, ends, steps])
             sliced_values = shape_data[starts[0] : ends[0] : steps[0]]
             return relax.const(sliced_values, "int64")
-        return emit_te_with_span(
-            bb, topi.strided_slice, data, starts, ends, strides=steps, axes=axes
-        )
+        return attach_span(relax.op.strided_slice(data, axes, starts, ends, steps))
 
 
 class Pad(OnnxOpConverter):


### PR DESCRIPTION
This PR follows up previous effort to changing operators into relax op implementation so that relax layout planning could be unblocked. This one specifically changes slice into strided_slice relax op.

CC @sunggg @jwfromm 