### PR TITLE
[TUZ-201] Support for end to end SpaceV5

### DIFF
--- a/python/tvm/octo/utils/target_info.py
+++ b/python/tvm/octo/utils/target_info.py
@@ -135,7 +135,22 @@ def get_cuda_target() -> tvm.target.Target:
     # To do so, lowercase the name and replace spaces with dases.
     target_name = "nvidia/" + product_name.replace(" ", "-").lower()
 
-    return tvm.target.Target(target_name)
+    target = tvm.target.Target(target_name)
+
+    # Attach libs if available.
+    # Check if thrust symbols are defined.
+    libs = []
+    if tvm._ffi.get_global_func("tvm.contrib.thrust.sum_scan", allow_missing=True):
+        libs.append("thrust")
+
+    # Append libs to target.
+    target = str(target)
+    if libs:
+        target += " -libs="
+        for lib in libs:
+            target += f"{lib},"
+
+    return tvm.target.Target(target)
 
 
 def get_default_threads() -> int:

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -193,7 +193,8 @@ def residual_block_patterns():
     for activation, name_postfix in [(None, ""), ("relax.nn.relu", "_relu")]:
         for check, base_patterns in [
             (_check_conv2d, conv2d_patterns()),
-            (_check_matmul, matmul_patterns()),
+            # TODO(jwfromm) Reenable once epilogue fusion is supported for bs > 1.
+            # (_check_matmul, matmul_patterns()),
         ]:
             for name, pat, arg_pat, _ in base_patterns:
                 # Append residual patterns only to those base patterns with bias add,


### PR DESCRIPTION
Change to octo utility so that it will autopopulate available external libs, so far we only check for `thrust`. 

I also disable epilogue fusion of matmul for now since it restricts batch size to 1.