### PR TITLE
[Unity] Fix typo in `get_cuda_target`

### DIFF
--- a/python/tvm/octo/utils/target_info.py
+++ b/python/tvm/octo/utils/target_info.py
@@ -122,7 +122,7 @@ def get_cuda_target() -> tvm.target.Target:
         A TVM target that fully describes the current devices CPU.
     """
     # If we cant find nvidia-smi, we wont be able to extract more information.
-    if shutil.which("llc") is None:
+    if shutil.which("nvidia-smi") is None:
         return tvm.target.Target("cuda")
 
     # Otherwise, query nvidia-smi to learn which gpu this is.


### PR DESCRIPTION
This PR fixes the typo in `get_cuda_target`, which is used to find the `nvidia-smi` command.