### PR TITLE
[TUZ-150][Minor] Add `shape_dict` param for Compile API

### DIFF
--- a/python/tvm/octo/compile.py
+++ b/python/tvm/octo/compile.py
@@ -30,7 +30,9 @@ from .schedule_cumsum import ScheduleCumsum
 
 
 def load_onnx_model(
-    model_file: Union[str, Path, onnx.ModelProto], shape_dict: Optional[Dict[str, List]] = None
+    model_file: Union[str, Path, onnx.ModelProto],
+    shape_dict: Optional[Dict[str, List]] = None,
+    dtype_dict: Optional[Union[str, Dict[str, str]]] = "float32",
 ) -> tvm.IRModule:
     """Convert an input onnx model into a relax module.
 
@@ -43,6 +45,10 @@ def load_onnx_model(
     shape_dict : Optional[Dict[str, List]]
         An optional dictionary that maps inputs to specific shapes. If not provided,
         the default values in the onnx graph will be used.
+
+    dtype_str: Optional[Union[str, Dict[str, str]]]
+        An optional string or dictionary that maps inputs to its specific data type.
+        If not provided, the default type of "float32" will be used.
 
     Returns
     -------
@@ -63,7 +69,7 @@ def load_onnx_model(
     model_file = gs.export_onnx(sorted_graph)
 
     # Convert the graph into a relax implementation.
-    relax_mod = from_onnx(model_file, shape_dict=shape_dict)
+    relax_mod = from_onnx(model_file, shape_dict=shape_dict, dtype_dict=dtype_dict)
 
     return relax_mod
 
@@ -112,6 +118,7 @@ def compile(
     model: Union[str, Path, onnx.ModelProto],
     target: Optional[tvm.target.Target] = None,
     shape_dict: Optional[Dict[str, List]] = None,
+    dtype_dict: Optional[Union[str, Dict[str, str]]] = "float32",
 ):
     """Entrypoint to compiling a model using the Unity Flow.
 
@@ -128,6 +135,10 @@ def compile(
     shape_dict : Optional[Dict[str, List]]
         An optional dictionary that maps inputs to specific shapes. If not provided,
         the default values in the onnx graph will be used.
+
+    type_dict : Optional[Union[str, Dict[str, str]]]
+        An optional string or dictionary that maps inputs to its specific data type.
+        If not provided, the default type of "float32" will be used.
 
     Returns
     -------
@@ -146,7 +157,7 @@ def compile(
         target = tvm.target.Target(target)
 
     # Convert model into a relax module.
-    relax_mod = load_onnx_model(model, shape_dict)
+    relax_mod = load_onnx_model(model, shape_dict=shape_dict, dtype_dict=dtype_dict)
 
     # Extract information about input shapes and types so we can
     # randomly generate them later if needed.

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -35,8 +35,7 @@ Not all TVM kernels currently support dynamic shapes, please file an issue on
 github.com/apache/tvm/issues if you hit an error with dynamic kernels.
 """
 import warnings
-from typing import Union, List, Dict, Tuple, Any
-import onnx.onnx_ml_pb2
+from typing import Union, Tuple, Optional, List, Dict, Any
 
 import numpy as _np
 
@@ -46,6 +45,8 @@ from tvm.ir import IRModule
 from tvm.ir.supply import NameSupply
 from tvm.relax import testing
 from tvm.relax.frontend.common import attach_span, emit_te_with_span
+
+import onnx.onnx_ml_pb2
 
 
 def get_type(elem_type: Union[str, int]) -> str:
@@ -2026,8 +2027,8 @@ class ONNXGraphImporter:
 
 def from_onnx(
     model: onnx.onnx_ml_pb2.GraphProto,
-    shape_dict: Dict[str, List] = None,
-    dtype_dict: str = "float32",
+    shape_dict: Optional[Dict[str, List]] = None,
+    dtype_dict: Optional[Union[str, Dict[str, str]]] = "float32",
     opset: int = None,
     sanitize_input_names: bool = True,
 ) -> Tuple[IRModule, Dict]:
@@ -2042,7 +2043,7 @@ def from_onnx(
         ONNX ModelProto after ONNX v1.1.0
     shape_dict : dict of str to tuple, optional
         The input shape to the graph
-    dtype_dict : str or dict of str to str
+    dtype_dict : str or dict of str to str, optional
         The input types to the graph
     opset : int, optional
         Override to autodetected opset.


### PR DESCRIPTION
Previously shape dict was not provided and we cannot easily specify the cases for `fp16`. This change allows we give the shape dict in top-level api and it's still compatible to use `float32` as default.

CC @jwfromm @sunggg 