### PR TITLE
[Tuning] Skip Thread-Binded Tasks

### DIFF
--- a/python/tvm/meta_schedule/relax_integration.py
+++ b/python/tvm/meta_schedule/relax_integration.py
@@ -27,6 +27,7 @@ from tvm.ir import IRModule
 from tvm.ir.transform import PassContext
 from tvm.runtime import NDArray
 from tvm.target import Target
+from tvm.tir import Schedule
 from tvm.tir.expr import IntImm
 
 from .builder import Builder
@@ -48,6 +49,11 @@ if TYPE_CHECKING:
 
 _extract_task_func = get_global_func(  # pylint: disable=invalid-name
     "relax.backend.MetaScheduleExtractTask",
+    allow_missing=False,
+)
+
+_block_collector_func = get_global_func(  # pylint: disable=invalid-name
+    "tvm.meta_schedule.block_collector",
     allow_missing=False,
 )
 
@@ -83,6 +89,18 @@ def extract_tasks(
     if params:
         mod = BindParams("main", params)(mod)
     return list(_extract_task_func(mod, target))
+
+
+def is_thread_binded(mod: IRModule) -> bool:
+    """Check if the schedule is thread binded."""
+    sch = Schedule(mod)
+    blocks = _block_collector_func(sch, None)
+    for block in blocks:
+        loops = sch.get_loops(block)
+        for loop in loops:
+            if sch.get(loop).thread_binding is not None:
+                return True
+    return False
 
 
 def extracted_tasks_to_tune_contexts(
@@ -124,6 +142,9 @@ def extracted_tasks_to_tune_contexts(
         get_loggers_from_work_dir(work_dir, [t.task_name for t in extracted_tasks]),
         fork_seed(seed, n=len(extracted_tasks)),
     ):
+        if is_thread_binded(task.dispatched[0]):
+            logger.warn("The task {task.task_name} is already thread binded, skipping it.")
+            continue
         tasks.append(
             TuneContext(
                 mod=task.dispatched[0],

--- a/python/tvm/meta_schedule/relax_integration.py
+++ b/python/tvm/meta_schedule/relax_integration.py
@@ -143,7 +143,7 @@ def extracted_tasks_to_tune_contexts(
         get_loggers_from_work_dir(work_dir, [t.task_name for t in extracted_tasks]),
         fork_seed(seed, n=len(extracted_tasks)),
     ):
-        if is_thread_binded(task.dispatched[0]):
+        if task.target.kind.name == "cuda" and is_thread_binded(task.dispatched[0]):
             warnings.warn("The task {task.task_name} is already thread binded, skipping it.")
             continue
         tasks.append(

--- a/python/tvm/meta_schedule/relax_integration.py
+++ b/python/tvm/meta_schedule/relax_integration.py
@@ -16,6 +16,7 @@
 # under the License.
 """Meta schedule integration with high-level IR"""
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+import warnings
 
 # isort: off
 from typing_extensions import Literal
@@ -143,7 +144,7 @@ def extracted_tasks_to_tune_contexts(
         fork_seed(seed, n=len(extracted_tasks)),
     ):
         if is_thread_binded(task.dispatched[0]):
-            logger.warn("The task {task.task_name} is already thread binded, skipping it.")
+            warnings.warn("The task {task.task_name} is already thread binded, skipping it.")
             continue
         tasks.append(
             TuneContext(

--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -118,6 +118,7 @@ SpaceGenerator SpaceGenerator::PostOrderApply(runtime::PackedFunc f_block_filter
 TVM_REGISTER_NODE_TYPE(PostOrderApplyNode);
 TVM_REGISTER_GLOBAL("meta_schedule.SpaceGeneratorPostOrderApply")
     .set_body_typed(SpaceGenerator::PostOrderApply);
+TVM_REGISTER_GLOBAL("tvm.meta_schedule.block_collector").set_body_typed(BlockCollector::Collect);
 
 }  // namespace meta_schedule
 }  // namespace tvm


### PR DESCRIPTION
For tasks like `cumsum` where it has been scheduled before tuning pass, we need to skip this task instead of triggering a failure for lack of support. This PR introduced a similar check as in `DefaultGPUSchedule` pass to skip such tasks.

CC: @sunggg @jwfromm 