### PR TITLE
[Frontend] Fuse some of the matmuls in attention

### DIFF
--- a/tests/python/relax/frontend/test_onnx_frontend.py
+++ b/tests/python/relax/frontend/test_onnx_frontend.py
@@ -1207,7 +1207,8 @@ def test_attention(dynamic):
             outputs=["output"],
             domain="com.microsoft",
             num_heads=num_heads,
-            mask_filter_value=mask_filter_value,
+            # TODO(jwfromm) OnnxRT doesnt work with this attribute, figure out why not.
+            # mask_filter_value=mask_filter_value,
             qkv_hidden_sizes=qkv_hidden_sizes,
         )
 


### PR DESCRIPTION
Our attention importer could be more efficient by grouping the Q, K, and V matmuls. This translates to a pretty sizeable speedup for attention based models.