### PR TITLE
Profile all cutlass kernels and use correct shapes

### DIFF
--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -28,6 +28,7 @@ import tvm
 from tvm import relax, relay, runtime
 from tvm._ffi.registry import register_func
 from tvm.contrib.nvcc import get_cuda_version
+from tvm.topi.utils import get_const_tuple
 
 from .gen_conv2d import CutlassConv2DProfiler
 from .gen_gemm import CutlassGemmProfiler
@@ -545,7 +546,7 @@ def _extract_relax_function_signature(f):
 
     for i, arg in enumerate(f.params):
         sinfo = arg.struct_info
-        signature["arg%d_shape" % i] = list(sinfo.shape)
+        signature["arg%d_shape" % i] = get_const_tuple(sinfo.shape)
         signature["arg%d_dtype" % i] = sinfo.dtype
 
     ret_sinfo = f.ret_struct_info

--- a/python/tvm/octo/compile.py
+++ b/python/tvm/octo/compile.py
@@ -108,7 +108,7 @@ def offload_cutlass(mod: tvm.IRModule, target: tvm.target.Target) -> tvm.IRModul
 
     # Construct CUTLASS codegen pass.
     cutlass_codegen_pass = relax.transform.RunCodegen(
-        {"cutlass": {"sm": sm, "find_first_valid": True}}
+        {"cutlass": {"sm": sm, "find_first_valid": False}}
     )
 
     # Generate code for matched cutlass kernels.


### PR DESCRIPTION
This PR fixed shapes used for profiling cutlass and updated config to profile all cutlasses (this will take more tuning time for kernel selection)

cc @jwfromm 