### PR TITLE
[TUZ145] Use ONNX op name to dynamically index ops

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -1956,6 +1956,9 @@ class ONNXGraphImporter:
         """Nodes are stored as directed acyclic graph."""
         for node_index, node in enumerate(graph.node):
             op_name = node.op_type
+            if node.name != "" or node.name is None:
+                op_name = node.name
+                node_index = int(node.split("_")[1])
             attr = self._parse_attr(node.attribute)
             # Create and populate input list.
             inputs = onnx_input()


### PR DESCRIPTION
As stated in #65, using stable indexes can be tricky. 
The following change for ops coming from an Onnx graph that keeps the schematics of ``name`` _  ``id`` uses this id which is unique to populate the span.  For cases where ``name`` is empty, it assigns the static id index.

@gigiblender @areusch 