### PR TITLE
[scorecard] Use local relax rather than `main`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -277,7 +277,3 @@ gallery/how_to/work_with_microtvm/micro_tvmc.py
 
 # GDB history file
 .gdb_history
-
-# scorecard files
-.fish_history
-models.yaml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,10 +44,6 @@ update_token:
       curl --request PUT --header "PRIVATE-TOKEN: $GITLAB_PERSONAL_ACCESS_TOKEN" \
       --silent --output /dev/null --show-error --fail \
       "https://gitlab.com/api/v4/projects/$CI_PROJECT_ID/variables/AWS_ECR_AUTH" --form "value=$AUTH"
-  only:
-    variables:
-      - $CI_PIPELINE_SOURCE == "web"
-      - $CI_COMMIT_REF_NAME == "main"
 
 docker_build:
   stage: build-docker
@@ -81,14 +77,16 @@ docker_build:
     name: 186900524924.dkr.ecr.us-west-2.amazonaws.com/scorecard:$TAG
   script: |
     set -eux
+    cd scorecard
     ls
-    ./scorecard/scripts/show_node_info.sh
+    ./scripts/show_node_info.sh
     mkdir model-data
     echo "$GCP_AUTH_JSON" > gcp_auth.json
+    curl -L -o models.yaml --header "PRIVATE-TOKEN: $RELAX_SCORECARD_GITLAB_PAT" "https://gitlab.com/api/v4/projects/$RELAX_SCORECARD_PROJECT_ID/repository/files/models.yaml/raw?ref=main"
     export UPLOAD_GCP=1
     export TEST_RUNS=10
     export WARMUP_RUNS=3
-    pytest --tb=native -rA -v -s -q scorecard/relax-coverage/ -k "$PYTEST_FILTER"
+    pytest --tb=native -rA -v -s -q relax-coverage/ -k "$PYTEST_FILTER"
 
 benchmarks-baseline:
   <<: *benchmark_template

--- a/scorecard/docker/Dockerfile.scorecard
+++ b/scorecard/docker/Dockerfile.scorecard
@@ -84,26 +84,19 @@ ENV ONNX_NIGHTLY_PATH /opt/onnx_nightly/lib/python3.10/site-packages
 
 # Build TVM
 ARG TVM_BUILT_AT
-RUN git clone https://github.com/octoml/relax --recursive
-RUN cd relax && git fetch origin && git config user.name test && git config user.email test@example.com
+COPY . .
+RUN git config user.name test && git config user.email test@example.com
 
 # Add this line to build in an un-merged PR
 # RUN PR_NUMBER=NN bash -c 'cd relax && curl -L "https://github.com/octoml/relax/pull/$PR_NUMBER.diff" | patch -p1 -N -d . && git add . && git commit -m"PR #$PR_NUMBER"'
-RUN bash -c 'cd relax && curl -L "https://github.com/octoml/relax/compare/TUZ-145.diff" | patch -p1 -N -d . && git add . && git commit -m"Add TUZ-145"'
+# RUN bash -c 'cd relax && curl -L "https://github.com/octoml/relax/compare/TUZ-145.diff" | patch -p1 -N -d . && git add . && git commit -m"Add TUZ-145"'
 
-RUN rm -rf relax/build
-COPY docker/build_relax.sh docker/build_relax.sh
-RUN bash docker/build_relax.sh
-RUN cd relax/python && python3 -m pip install --no-cache-dir -e .
+RUN rm -rf build
+RUN bash scorecard/docker/build_relax.sh
+RUN cd python && python3 -m pip install --no-cache-dir -e .
 
 # aws CLI
 RUN pip install awscli
-
-# testbench code
-COPY relax-coverage relax-coverage
-COPY schema schema
-COPY models.yaml models.yaml
-COPY hub_models.yaml hub_models.yaml
 
 ENV ORT_TENSORRT_FP16_ENABLE 1
 ENV AWS_DEFAULT_REGION us-west-2

--- a/scorecard/docker/build.sh
+++ b/scorecard/docker/build.sh
@@ -19,7 +19,7 @@
 set -eux
 
 set +x
-source docker/retry.sh
+source scorecard/docker/retry.sh
 set -x
 
 PUSH_TO_ECR="${PUSH_TO_ECR:=0}"
@@ -33,7 +33,7 @@ if [ "$NO_CACHE" == "1" ]; then
     CACHE_ARG="--no-cache"
 fi
 
-retry $RETRIES docker build . --build-arg TVM_BUILT_AT=$TVM_BUILT_AT -f docker/Dockerfile.${IMAGE_NAME} $CACHE_ARG --tag ${IMAGE_NAME}:latest
+retry $RETRIES docker build . --build-arg TVM_BUILT_AT=$TVM_BUILT_AT -f scorecard/docker/Dockerfile.${IMAGE_NAME} $CACHE_ARG --tag ${IMAGE_NAME}:latest
 
 # # testing code to skip the docker build but still have an image to work with
 # docker pull hello-world

--- a/scorecard/docker/build_relax.sh
+++ b/scorecard/docker/build_relax.sh
@@ -17,7 +17,7 @@
 # under the License.
 
 set -euxo pipefail
-cd relax
+git submodule update --init --recursive --jobs 0
 mkdir -p build
 cd build
 cmake -GNinja \
@@ -27,8 +27,8 @@ cmake -GNinja \
     -DSUMMARIZE=1 \
     -DUSE_CUDA=1 \
     -DUSE_MICRO=1 \
-    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DUSE_CUTLASS=1 \
     -DUSE_THRUST=1 \
     ..
-cmake --build . --
+cmake --build .

--- a/scorecard/docker/dev.sh
+++ b/scorecard/docker/dev.sh
@@ -44,17 +44,16 @@ docker run \
     --env WARMUP_RUNS=$WARMUP_RUNS \
     --env UPLOAD_GCP=$UPLOAD_GCP \
     --env UPLOAD_PG=$UPLOAD_PG \
-    -v $PWD/$MODEL_DATA_DIR:/opt/scorecard/model-data \
-    -v $GCP_AUTH_JSON:/opt/scorecard/gcp_auth.json:ro \
-    -v $PWD/.coverage_results:/opt/scorecard/.coverage_results \
-    -v $PWD/.tuning_records:/opt/scorecard/.tuning_records \
+    -v $PWD/$MODEL_DATA_DIR:/opt/scorecard/scorecard/model-data \
+    -v $GCP_AUTH_JSON:/opt/scorecard/scorecard/gcp_auth.json:ro \
+    -v $PWD/.coverage_results:/opt/scorecard/scorecard/.coverage_results \
+    -v $PWD/.tuning_records:/opt/scorecard/scorecard/.tuning_records \
     -v $PWD/.fish_history:/root/.local/share/fish/fish_history \
-    -v $PWD/relax-coverage:/opt/scorecard/relax-coverage \
-    -v $PWD/schema:/opt/scorecard/schema \
-    -v $PWD/scripts:/opt/scorecard/scripts \
-    -v $PWD/models.yaml:/opt/scorecard/models.yaml \
-    -v $PWD/hub_models.yaml:/opt/scorecard/hub_models.yaml \
-    --mount type=volume,dst=/opt/scorecard/relax,volume-driver=local,volume-opt=type=none,volume-opt=o=bind,volume-opt=device=$PWD/doc-relax \
+    -v $PWD/relax-coverage:/opt/scorecard/scorecard/relax-coverage \
+    -v $PWD/schema:/opt/scorecard/scorecard/schema \
+    -v $PWD/scripts:/opt/scorecard/scorecard/scripts \
+    -v $PWD/models.yaml:/opt/scorecard/scorecard/models.yaml \
+    -v $PWD/hub_models.yaml:/opt/scorecard/scorecard/hub_models.yaml \
     --mount type=volume,dst=/root/.cache/onnx/hub,volume-driver=local,volume-opt=type=none,volume-opt=o=bind,volume-opt=device=$PWD/onnx-hub-cache \
     -it $IMAGE \
     fish

--- a/scorecard/relax-coverage/runners/relax_base.py
+++ b/scorecard/relax-coverage/runners/relax_base.py
@@ -85,7 +85,6 @@ class RelaxBase(BaseRunner):
                 return e, ImportError.FAILED_OCTO_COMPILE, 0, [], []
 
         compile_time_ms = compile_timer.ms_duration
-        breakpoint()
 
         # NOTE: ONNX frontend sanitizes input names. This hack is brittle and presumes Python dict ordering is the same
         # between invocations. The real fix should be that OctoModel carries a mapping of framework names to Relax names.

--- a/scorecard/relax-coverage/test_coverage.py
+++ b/scorecard/relax-coverage/test_coverage.py
@@ -357,9 +357,9 @@ def matches(pattern: Union[str, re.Pattern], text: str) -> bool:
     return pattern.search(text) is not None
 
 
-@parameterize_configs(MODELS)
-def test_offload_coverage(request, show_test_name, result_directory, run_config: Dict[str, Any]):
-    """ """
+# @parameterize_configs(MODELS)
+# def test_offload_coverage(request, show_test_name, result_directory, run_config: Dict[str, Any]):
+#     """ """
 
 
 @parameterize_configs(MODELS)

--- a/tests/lint/check_file_type.py
+++ b/tests/lint/check_file_type.py
@@ -95,6 +95,7 @@ ALLOW_EXTENSION = {
     "ini",
     # for scorecard
     "jsonschema",
+    "dockerignore",
 }
 
 # List of file names allowed

--- a/tests/lint/rat-excludes
+++ b/tests/lint/rat-excludes
@@ -45,6 +45,7 @@ package-list
 MANIFEST
 .eslintignore
 .gitignore
+.dockerignore
 .gitattributes
 .gitmodules
 .clang-format


### PR DESCRIPTION
This includes a number of fixes on top of the initial scorecard infra, mainly to enable using the local relax version from the current branch/PR rather than checking out a fresh one from `main`.

cc @areusch @jwfromm 