### PR TITLE
[scorecard] Use A10G runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,7 +83,7 @@ docker_build:
 
 .benchmark_template: &benchmark_template
   tags:
-    - gpu-triton
+    - gpu-a10g
   stage: test
   dependencies:
     - docker_build

--- a/scorecard/relax-coverage/runners/cli.py
+++ b/scorecard/relax-coverage/runners/cli.py
@@ -221,7 +221,7 @@ def parse_args(valid_executors: List[str]):
         sub.add_argument(
             "--cuda-sm",
             type=int,
-            default=75,
+            default=86,
             help="CUDA target sm level (default: 75, compute capability for Tesla T4)",
         )
         sub.add_argument(


### PR DESCRIPTION
This changes the CI to run on aws instances with A10G GPUs rather than T4s. This is based on #73
