### PR TITLE
[Relax][ONNX] Add Dropout operation

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -2044,7 +2044,7 @@ class ONNXGraphImporter:
                 else:
                     inputs.append(None)
             i_name = self._parse_value_proto(node)
-            outputs = node.output
+            outputs = self._fix_outputs(op_name, node.output)
             attr["tvm_custom"] = {}
             attr["tvm_custom"]["name"] = i_name
             attr["tvm_custom"]["num_outputs"] = len(outputs)
@@ -2161,6 +2161,17 @@ class ONNXGraphImporter:
         else:
             raise NotImplementedError("Operator {} not implemented.".format(op_name))
         return sym
+
+    def _fix_outputs(self, op_name, outputs):
+        """A hack to handle dropout or similar operator that have more than one out
+        in ONNX.
+        """
+        if op_name == "Dropout":
+            if len(outputs) == 1:
+                return outputs
+            # TODO(vvchernov): support dropout mask?
+            outputs = outputs[:-1]
+        return outputs
 
 
 def from_onnx(

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -1387,6 +1387,84 @@ class Flatten(OnnxOpConverter):
         return attach_span(relax.op.reshape(inputs[0], new_shape))
 
 
+class Dropout(OnnxOpConverter):
+    """Converts an onnx Dropout node into an equivalent Relax expression."""
+
+    @classmethod
+    def _check_dtype(cls, dtype, add_valid_types = []):
+        valid_types = ["float", "float32", "double", "float64", "float16"]
+        valid_types += add_valid_types
+        assert dtype in valid_types, "Types {} are supported only, but {} is given".format(
+            valid_types, dtype
+        )
+
+    @classmethod
+    def _impl_v1(cls, bb, inputs, attr):
+        data = inputs[0]
+        cls._check_dtype(data.checked_type.dtype)
+
+        mode = attr.get("is_test", 0)
+        if mode != 0:
+            return data
+
+        rate = attr.get("ratio", 0.5)
+        if rate == 0:
+            return data
+        return relax.op.nn.dropout(data, rate)
+
+    @classmethod
+    def _impl_v7(cls, bb, inputs, attr):
+        data = inputs[0]
+        cls._check_dtype(data.checked_type.dtype)
+
+        rate = attr.get("ratio", 0.5)
+        if rate == 0:
+            return data
+        return relax.op.nn.dropout(data, rate)
+
+    @classmethod
+    def _impl_v12(cls, bb, inputs, attr):
+        data = inputs[0]
+        cls._check_dtype(data.checked_type.dtype)
+
+        if attr["seed"] is not None:
+            warnings.warn("Seed for dropout is not supported now")
+
+        if len(inputs) < 3: # training_mode is False and inputs[1] (ratio) is ignored
+            return data
+
+        mode = inputs[2] # training_mode
+        if mode is None or mode == False:
+            # TODO(vvchernov): possibly at inference mode we should return mask with ones also
+            return data
+
+        rate = inputs[1]
+        if rate == 0:
+            return data
+        return relax.op.nn.dropout(data, rate)
+
+    @classmethod
+    def _impl_v13(cls, bb, inputs, attr):
+        data = inputs[0]
+        cls._check_dtype(data.checked_type.dtype, ["bfloat16"])
+
+        if attr["seed"] is not None:
+            warnings.warn("Seed for dropout is not supported now")
+
+        if len(inputs) < 3: # training_mode is False and inputs[1] (ratio) is ignored
+            return data
+
+        mode = inputs[2] # training_mode
+        if mode is None or mode == False:
+            # TODO(vvchernov): possibly at inference mode we should return mask with ones also
+            return data
+
+        rate = inputs[1]
+        if rate == 0:
+            return data
+        return relax.op.nn.dropout(data, rate)
+
+
 class LayerNormalization(OnnxOpConverter):
     """Converts an onnx LayerNormalization node into an equivalent Relax expression."""
 
@@ -1791,6 +1869,7 @@ def _get_convert_map():
         "BatchNormalization": BatchNormalization,
         "GlobalAveragePool": GlobalAveragePool,
         "Flatten": Flatten,
+        "Dropout": Dropout,
         "MaxPool": MaxPool,
         "Identity": Identity,
         "Resize": Resize,

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -1391,7 +1391,7 @@ class Dropout(OnnxOpConverter):
     """Converts an onnx Dropout node into an equivalent Relax expression."""
 
     @classmethod
-    def _check_dtype(cls, dtype, add_valid_types = []):
+    def _check_dtype(cls, dtype, add_valid_types=[]):  # pylint: disable=dangerous-default-value
         valid_types = ["float", "float32", "double", "float64", "float16"]
         valid_types += add_valid_types
         assert dtype in valid_types, "Types {} are supported only, but {} is given".format(
@@ -1430,11 +1430,11 @@ class Dropout(OnnxOpConverter):
         if attr["seed"] is not None:
             warnings.warn("Seed for dropout is not supported now")
 
-        if len(inputs) < 3: # training_mode is False and inputs[1] (ratio) is ignored
+        if len(inputs) < 3:  # training_mode is False and inputs[1] (ratio) is ignored
             return data
 
-        mode = inputs[2] # training_mode
-        if mode is None or mode == False:
+        mode = inputs[2]  # training_mode
+        if mode is None or not mode:
             # TODO(vvchernov): possibly at inference mode we should return mask with ones also
             return data
 
@@ -1451,11 +1451,11 @@ class Dropout(OnnxOpConverter):
         if attr["seed"] is not None:
             warnings.warn("Seed for dropout is not supported now")
 
-        if len(inputs) < 3: # training_mode is False and inputs[1] (ratio) is ignored
+        if len(inputs) < 3:  # training_mode is False and inputs[1] (ratio) is ignored
             return data
 
-        mode = inputs[2] # training_mode
-        if mode is None or mode == False:
+        mode = inputs[2]  # training_mode
+        if mode is None or not mode:
             # TODO(vvchernov): possibly at inference mode we should return mask with ones also
             return data
 

--- a/python/tvm/relax/transform/legalize_ops/nn.py
+++ b/python/tvm/relax/transform/legalize_ops/nn.py
@@ -270,8 +270,7 @@ def _nn_group_norm(bb: BlockBuilder, call: Call) -> Expr:
 
 @register_legalize("relax.nn.dropout")
 def _nn_dropout(bb: BlockBuilder, call: Call) -> Expr:
-    logging.info("Dropout is handled by frontend translator at this moment and is not legalized.")
-    return call
+    return bb.call_te(topi.nn.dropout, call.args[0])
 
 
 def _te_attention(q: te.Tensor, k: te.Tensor, v: te.Tensor, bias: te.Tensor) -> te.Tensor:

--- a/python/tvm/topi/nn/elemwise.py
+++ b/python/tvm/topi/nn/elemwise.py
@@ -103,3 +103,29 @@ def prelu(x, slope, axis=1):
         return tvm.tir.Select(xval > 0, xval, xval * slope(indices[axis]))
 
     return te.compute(x.shape, _compute_channelwise)
+
+
+@tvm.te.tag_scope(tag=tag.ELEMWISE)
+def dropout(x):
+    """Take dropout of input x for inference.
+
+    Parameters
+    ----------
+    x : tvm.te.Tensor
+        Input argument.
+
+    Returns
+    -------
+    y : tvm.te.Tensor
+        The result.
+    """
+
+    def _compute_channelwise(*indices):
+        xval = x(*indices)
+        return tvm.tir.Cast("bool", xval)
+
+    def _compute_identity(*indices):
+        xval = x(*indices)
+        return xval
+
+    return te.compute(x.shape, _compute_identity), te.compute(x.shape, _compute_channelwise)


### PR DESCRIPTION
Add Dropout operation to ONNX front-end of Relax.

**Notes:** 1. Unfortunately there is no sample for CI test of operation with randomize. It should be discussed how to do it carefully. 2. It is strange thing that for this op on TOPI side the training mode is supported only, for inference mode we potentially can skip it in some pass due to the output is equal to input (if optional second output can be skipped)