### PR TITLE
[Relax][ONNX] add AveragePool op

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -1308,7 +1308,44 @@ class BatchNormalization(OnnxOpConverter):
         )
 
 
-class MaxPool(OnnxOpConverter):
+class Pool:
+    @classmethod
+    def _get_input_spatial_shape(cls, tensor):
+        # shape is (N x C x D1 x D2 ... Dn)
+        return _np.array([int(d) for d in tensor.struct_info.shape], dtype="int64")[2:]
+
+    @classmethod
+    def _prepare_auto_pads(cls, auto_pad, data, kernel_shape, strides, dilations):
+        input_spatial_shape = cls._get_input_spatial_shape(data)
+        output_spatial_shape = [0 for _ in input_spatial_shape]
+
+        pads = _np.array([(0, 0) for _ in range(len(kernel_shape))])
+
+        for i, _ in enumerate(input_spatial_shape):
+            if auto_pad == "SAME_UPPER":
+                output_spatial_shape[i] = int(_np.ceil(input_spatial_shape[i] / strides[i]))
+            else:
+                output_spatial_shape[i] = int(_np.floor(input_spatial_shape[i] / strides[i]))
+            pad_i = (
+                (output_spatial_shape[i] - 1) * strides[i]
+                + ((kernel_shape[i] - 1) * dilations[i] + 1)
+                - input_spatial_shape[i]
+            )
+            if auto_pad == "SAME_UPPER":
+                pads[i, 0] = pad_i // 2
+                pads[i, 1] = pad_i - pads[i, 0]
+            else:
+                pads[i, 1] = pad_i // 2
+                pads[i, 0] = pad_i - pads[i, 1]
+
+        # TODO(agladyshev): for now we support only 2D kernel
+        # (top, left, bottom, right)
+        flatten_pads = [pads[0][0], pads[1][0], pads[0][1], pads[1][1]]
+        pads = tuple(flatten_pads)
+        return pads
+
+
+class MaxPool(OnnxOpConverter, Pool):
     """Converts an onnx MaxPool node into an equivalent Relax expression."""
 
     @classmethod
@@ -1331,41 +1368,41 @@ class MaxPool(OnnxOpConverter):
         ], f"Value {auto_pad} in attribute auto_pad is invalid."
 
         if auto_pad in ("SAME_UPPER", "SAME_LOWER"):
-            input_spatial_shape = cls._get_input_spatial_shape(data)
-            output_spatial_shape = [0 for _ in input_spatial_shape]
-
-            pads = _np.array([(0, 0) for _ in range(len(kernel_shape))])
-
-            for i, _ in enumerate(input_spatial_shape):
-                if auto_pad == "SAME_UPPER":
-                    output_spatial_shape[i] = int(_np.ceil(input_spatial_shape[i] / strides[i]))
-                else:
-                    output_spatial_shape[i] = int(_np.floor(input_spatial_shape[i] / strides[i]))
-                pad_i = (
-                    (output_spatial_shape[i] - 1) * strides[i]
-                    + ((kernel_shape[i] - 1) * dilations[i] + 1)
-                    - input_spatial_shape[i]
-                )
-                if auto_pad == "SAME_UPPER":
-                    pads[i, 0] = pad_i // 2
-                    pads[i, 1] = pad_i - pads[i, 0]
-                else:
-                    pads[i, 1] = pad_i // 2
-                    pads[i, 0] = pad_i - pads[i, 1]
-
-            # TODO(agladyshev): for now we support only 2D kernel
-            # (top, left, bottom, right)
-            flatten_pads = [pads[0][0], pads[1][0], pads[0][1], pads[1][1]]
-            pads = tuple(flatten_pads)
+            pads = cls._prepare_auto_pads(auto_pad, data, kernel_shape, strides, dilations)
 
         return attach_span(
             relax.op.nn.max_pool2d(data, kernel_shape, strides, pads, dilations, ceil_mode)
         )
 
+
+class AveragePool(OnnxOpConverter, Pool):
+    """Converts an onnx MaxPool node into an equivalent Relax expression."""
+
     @classmethod
-    def _get_input_spatial_shape(cls, tensor):
-        # shape is (N x C x D1 x D2 ... Dn)
-        return _np.array([int(d) for d in tensor.struct_info.shape], dtype="int64")[2:]
+    def _impl_v12(cls, bb, inputs, attr):
+        # Unpack inputs and attributes.
+        data = inputs[0]
+        auto_pad = attr.get("auto_pad", b"NOTSET").decode("utf-8")
+        ceil_mode = attr.get("ceil_mode", 0)
+        dilations = attr.get("dilations", [1, 1])
+        kernel_shape = attr.get("kernel_shape")
+        pads = attr.get("pads", 0)
+        strides = attr.get("strides", 1)
+
+        assert len(kernel_shape) == 2, "Currently only 2D pooling is supported."
+        assert auto_pad in [
+            "NOTSET",
+            "SAME_UPPER",
+            "SAME_LOWER",
+            "VALID",
+        ], f"Value {auto_pad} in attribute auto_pad is invalid."
+
+        if auto_pad in ("SAME_UPPER", "SAME_LOWER"):
+            pads = cls._prepare_auto_pads(auto_pad, data, kernel_shape, strides, dilations)
+
+        return attach_span(
+            relax.op.nn.avg_pool2d(data, kernel_shape, strides, pads, dilations, ceil_mode)
+        )
 
 
 class GlobalAveragePool(OnnxOpConverter):
@@ -1792,6 +1829,7 @@ def _get_convert_map():
         "GlobalAveragePool": GlobalAveragePool,
         "Flatten": Flatten,
         "MaxPool": MaxPool,
+        "AveragePool": AveragePool,
         "Identity": Identity,
         "Resize": Resize,
         "Einsum": Einsum,

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -1309,6 +1309,8 @@ class BatchNormalization(OnnxOpConverter):
 
 
 class Pool:
+    """Base class for MaxPool and AveragePool nodes."""
+
     @classmethod
     def _get_input_spatial_shape(cls, tensor):
         # shape is (N x C x D1 x D2 ... Dn)
@@ -1345,7 +1347,7 @@ class Pool:
         return pads
 
     @classmethod
-    def _base_impl_v12(cls, bb, inputs, attr, type="max"):
+    def _base_impl(cls, bb, inputs, attr, type="max"):
         # Unpack inputs and attributes.
         data = inputs[0]
         auto_pad = attr.get("auto_pad", b"NOTSET").decode("utf-8")
@@ -1383,7 +1385,7 @@ class MaxPool(OnnxOpConverter, Pool):
 
     @classmethod
     def _impl_v12(cls, bb, inputs, attr):
-        return cls._base_impl_v12(cls, bb, inputs, attr)
+        return cls._base_impl(bb, inputs, attr)
 
 
 class AveragePool(OnnxOpConverter, Pool):
@@ -1391,7 +1393,7 @@ class AveragePool(OnnxOpConverter, Pool):
 
     @classmethod
     def _impl_v12(cls, bb, inputs, attr):
-         return cls._base_impl_v12(cls, bb, inputs, attr, "avg")
+        return cls._base_impl(bb, inputs, attr, "avg")
 
 
 class GlobalAveragePool(OnnxOpConverter):

--- a/src/relax/op/nn/pooling.cc
+++ b/src/relax/op/nn/pooling.cc
@@ -71,8 +71,6 @@ Expr max_pool2d(Expr data, Array<IntImm> pool_size, Array<IntImm> strides, Array
 }
 
 TVM_REGISTER_GLOBAL("relax.op.nn.max_pool2d").set_body_typed(max_pool2d);
-// TODO(agladyshev): create avg_pool2d for set_body_typed (see above)
-TVM_REGISTER_GLOBAL("relax.op.nn.avg_pool2d").set_body_typed(max_pool2d);
 
 StructInfo InferStructInfoPool2D(const Call& call, const BlockBuilder& ctx) {
   TensorStructInfo data_sinfo = GetUnaryInputTensorStructInfo(call, ctx);
@@ -144,6 +142,7 @@ TVM_REGISTER_OP("relax.nn.max_pool2d")
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutPool2d)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow);
 
+/* relax.nn.avg_pool2d */
 Expr avg_pool2d(Expr data, Array<IntImm> pool_size, Array<IntImm> strides, Array<IntImm> padding,
                 Array<IntImm> dilation, bool ceil_mode, String layout,
                 Optional<String> out_layout) {
@@ -160,13 +159,6 @@ TVM_REGISTER_OP("relax.nn.avg_pool2d")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoPool2D)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutPool2d)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow);
-
-// TODO(agladyshev): create InferStructInfoAvgPool2D for set_attr (see above)
-TVM_REGISTER_OP("relax.nn.avg_pool2d")
-    .set_num_inputs(1)
-    .add_argument("data", "Tensor", "The input tensor")
-    .set_attrs_type<MaxPool2DAttrs>()
-    .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoMaxPool2D);
 
 /* relax.nn.adaptive_avg_pool2d */
 TVM_REGISTER_NODE_TYPE(AdaptivePool2DAttrs);

--- a/src/relax/op/nn/pooling.cc
+++ b/src/relax/op/nn/pooling.cc
@@ -71,6 +71,8 @@ Expr max_pool2d(Expr data, Array<IntImm> pool_size, Array<IntImm> strides, Array
 }
 
 TVM_REGISTER_GLOBAL("relax.op.nn.max_pool2d").set_body_typed(max_pool2d);
+// TODO(agladyshev): create avg_pool2d for set_body_typed (see above)
+TVM_REGISTER_GLOBAL("relax.op.nn.avg_pool2d").set_body_typed(max_pool2d);
 
 StructInfo InferStructInfoPool2D(const Call& call, const BlockBuilder& ctx) {
   TensorStructInfo data_sinfo = GetUnaryInputTensorStructInfo(call, ctx);
@@ -158,6 +160,13 @@ TVM_REGISTER_OP("relax.nn.avg_pool2d")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoPool2D)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutPool2d)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow);
+
+// TODO(agladyshev): create InferStructInfoAvgPool2D for set_attr (see above)
+TVM_REGISTER_OP("relax.nn.avg_pool2d")
+    .set_num_inputs(1)
+    .add_argument("data", "Tensor", "The input tensor")
+    .set_attrs_type<MaxPool2DAttrs>()
+    .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoMaxPool2D);
 
 /* relax.nn.adaptive_avg_pool2d */
 TVM_REGISTER_NODE_TYPE(AdaptivePool2DAttrs);

--- a/tests/python/relax/frontend/test_onnx_frontend.py
+++ b/tests/python/relax/frontend/test_onnx_frontend.py
@@ -1567,7 +1567,7 @@ def test_batch_norm():
     check_correctness(model)
 
 
-# TODO(agladyshev): MaxPool, AveragePool
+@pytest.mark.parametrize("node_type", ["MaxPool", "AveragePool"])
 def test_max_pool(node_type):
     # Pool2D
     verify_unary(

--- a/tests/python/relax/frontend/test_onnx_frontend.py
+++ b/tests/python/relax/frontend/test_onnx_frontend.py
@@ -1567,10 +1567,11 @@ def test_batch_norm():
     check_correctness(model)
 
 
-def test_max_pool():
+# TODO(agladyshev): MaxPool, AveragePool
+def test_max_pool(node_type):
     # Pool2D
     verify_unary(
-        "MaxPool",
+        node_type,
         [1, 1, 32, 32],
         dict(
             auto_pad="NOTSET",
@@ -1581,7 +1582,7 @@ def test_max_pool():
     )
     # Pool2D with stride
     verify_unary(
-        "MaxPool",
+        node_type,
         [1, 1, 32, 32],
         dict(
             auto_pad="NOTSET",
@@ -1592,7 +1593,7 @@ def test_max_pool():
     )
     # Pool2D with stride and autopadding
     verify_unary(
-        "MaxPool",
+        node_type,
         [1, 1, 32, 32],
         dict(
             auto_pad="SAME_UPPER",
@@ -1602,7 +1603,7 @@ def test_max_pool():
         ),
     )
     verify_unary(
-        "MaxPool",
+        node_type,
         [1, 1, 32, 32],
         dict(
             auto_pad="SAME_LOWER",
@@ -1612,7 +1613,7 @@ def test_max_pool():
         ),
     )
     verify_unary(
-        "MaxPool",
+        node_type,
         [1, 1, 32, 32],
         dict(
             auto_pad="VALID",

--- a/tests/python/relax/frontend/test_onnx_frontend.py
+++ b/tests/python/relax/frontend/test_onnx_frontend.py
@@ -1568,7 +1568,7 @@ def test_batch_norm():
 
 
 @pytest.mark.parametrize("node_type", ["MaxPool", "AveragePool"])
-def test_max_pool(node_type):
+def test_pool(node_type):
     # Pool2D
     verify_unary(
         node_type,


### PR DESCRIPTION
Add AveragePool operation (just now for 2d tensors only) to ONNX front-end and FFI of Relax.
CI tests were updated