### PR TITLE
[scorecard] Use a separate build directory and stable images

### DIFF
--- a/scorecard/README.md
+++ b/scorecard/README.md
@@ -70,7 +70,7 @@ successfully.
 
 ### Build the Docker Image
 
-Scorecard CI will build the Docker image each time before it runs benchmarks and store the resulting image in AWS's ECR. You can pull this image locally after using `docker/login.py` via the image at the end of the logs of any `docker_build` job in a scorecard GitLab pipeline ([example](https://gitlab.com/octoml/relax-scorecard-ci2/-/jobs/4061474766)).
+Scorecard CI will build the Docker image each time before it runs benchmarks and store the resulting image in AWS's ECR. You can pull this image locally after using `docker/login.py` via the image at the end of the logs of any `docker_build` job in a scorecard GitLab pipeline ([example](https://gitlab.com/octoml/relax-scorecard-ci2/-/jobs/4061474766)). `local.py` will also determine an image to use from ECR if none is specified, so if you want to use those images you can skip this step.
 
 You can also build the image locally, though you will still need to authorize with AWS to download models if you do not have them on disk.
 
@@ -114,6 +114,9 @@ python3 local.py --prebuilt-relax
 
 # Use a different Docker image, in this case a locally built version
 python3 local.py --image scorecard:latest
+
+# Use a different Docker image, in this case the latest scorecard image in ECR
+python3 local.py --image latest
 
 # Run a command other than 'bash'
 python3 local.py pytest relax-coverage/ -k 'stable-diffusion and relax-cuda'

--- a/scorecard/docker/build_relax.sh
+++ b/scorecard/docker/build_relax.sh
@@ -19,8 +19,8 @@
 set -euxo pipefail
 git config --global --add safe.directory /opt/scorecard
 git submodule update --init --recursive --jobs 0
-mkdir -p build
-cd build
+mkdir -p build-scorecard
+cd build-scorecard
 cmake -GNinja \
     -DCMAKE_LINKER=/usr/bin/lld-15 \
     -DCMAKE_CUDA_ARCHITECTURES=75 \

--- a/scorecard/local.py
+++ b/scorecard/local.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--image",
         help="Docker image to use (can be a specific docker image or 'latest' (alias for "
-        "186900524924.dkr.ecr.us-west-2.amazonaws.com/scorecard:latest), by default this "
+        "186900524924.dkr.ecr.us-west-2.amazonaws.com/scorecard:latest). If not specified, "
         "will search for the most recent image for the current git tree)",
     )
     parser.add_argument(


### PR DESCRIPTION
This adds 2 things:
    1. Builds in `build-scorecard` to not pollute `build` for local runs
    2. Determines a stable image (i.e. one that doesn't change from
       run-to-run dynamically by searching ECR for one built from the
       base commit with `relax`.
