### PR TITLE
[scorecard] Set build-scorecard directory in env

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,6 +65,7 @@ docker_build:
     - update_token
   tags:
     - cpu-sole-tenant
+  timeout: 2h
   script:
     - apk add --update py-pip
     - pip install awscli

--- a/scorecard/docker/Dockerfile.scorecard
+++ b/scorecard/docker/Dockerfile.scorecard
@@ -91,7 +91,8 @@ RUN git config user.name test && git config user.email test@example.com
 # RUN PR_NUMBER=NN bash -c 'cd relax && curl -L "https://github.com/octoml/relax/pull/$PR_NUMBER.diff" | patch -p1 -N -d . && git add . && git commit -m"PR #$PR_NUMBER"'
 # RUN bash -c 'cd relax && curl -L "https://github.com/octoml/relax/compare/TUZ-145.diff" | patch -p1 -N -d . && git add . && git commit -m"Add TUZ-145"'
 
-RUN rm -rf build
+RUN rm -rf build-scorecard
+ENV TVM_LIBRARY_PATH /opt/scorecard/build-scorecard
 RUN bash scorecard/docker/build_relax.sh
 RUN cd python && python3 -m pip install --no-cache-dir -e .
 


### PR DESCRIPTION
This sets the build up so it can find the TVM build and avoid
https://gitlab.com/octoml/relax-scorecard-ci2/-/jobs/4097363694
