### PR TITLE
Fix scorecard/local.py when git sha1 is numbers only

### DIFF
--- a/scorecard/local.py
+++ b/scorecard/local.py
@@ -91,7 +91,7 @@ def find_scorecard_image_tag() -> str:
         "--filter",
         "tagStatus=TAGGED",
         "--query",
-        f"imageIds[?contains(imageTag, `{short_sha}`)].[imageTag]",
+        f"imageIds[?contains(imageTag, '{short_sha}')].[imageTag]",
     ]
     data = json.loads(subprocess.check_output(cmd, encoding="utf-8"))
 


### PR DESCRIPTION
Recently got this error when running `local.py`:

```
'in <string>' requires string as left operand, not int
```

Fixes this issue by changing the quoting used in the `aws ecr` filter.

@driazati 