### PR TITLE
Find models.yaml relative to repo root in local.py

### DIFF
--- a/scorecard/local.py
+++ b/scorecard/local.py
@@ -137,7 +137,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--models-yaml",
-        default="gitlab-scorecard/models.yaml",
+        default=REPO_ROOT / "scorecard/gitlab-scorecard/models.yaml",
         help="Path to models.yaml (default: gitlab-scorecard/models.yaml)",
     )
     parser.add_argument(


### PR DESCRIPTION
Allows invoking local.py from repo root. @driazati 